### PR TITLE
Refine planning docs and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# CLI Agent (MVP)
+
+This project aims to build a command‑line software development assistant inspired by the Cline VSCode extension. The agent will run entirely in the terminal and communicate with a remote language model to execute development tasks such as running shell commands and editing files.
+
+Key ideas:
+
+- **Reuse Cline prompts** – Cline provides detailed system and command prompts describing the agent's tools and workflow. These prompts are ported to Python so that the CLI agent can leverage the same language and capabilities.
+- **Lightweight orchestration** – Instead of relying on the CrewAI framework, the agent implements its own simple loop in Python to send messages to the model, parse tool instructions, and apply the requested actions.
+- **Extensible tools** – Tools like `execute_command`, `read_file`, and `write_to_file` will be implemented in Python. Additional features such as MCP integration or browser actions can be added later.
+
+The repository contains planning documents in `docs/` and reference code from the original Cline extension under `vendor/`. The `src/` directory will host the Python implementation.
+
+This MVP is a work in progress. See `docs/MVP-TASKS.md` for the ordered list of development steps.

--- a/docs/CODEX_PLAN.md
+++ b/docs/CODEX_PLAN.md
@@ -1,0 +1,88 @@
+# Plan for CLI-based Software Development Agent
+
+This repository contains references to two projects under `vendor/`:
+
+- **Cline** – a VSCode extension implementing an agentic coding assistant. It includes
+  complex prompts, tool definitions and the agent loop for interacting with the
+  user via VSCode. Key files:
+  - `vendor/cline/src/core/prompts/system.ts` – defines the system prompt and
+    detailed documentation for all tools such as `execute_command`, `read_file`,
+    `write_to_file`, `replace_in_file`, `search_files`, `browser_action`, etc.
+  - `vendor/cline/src/core/prompts/commands.ts` – prompt templates for special
+    commands (`new_task`, `condense`, ...).
+  - `vendor/cline/src/core/assistant-message` – logic to parse the assistant
+    output into text blocks and structured *tool_use* blocks.
+  - `vendor/cline/src/core/task/index.ts` – implements the full task loop inside
+    VSCode (sending user input to the LLM, executing tool calls, tracking
+    checkpoints, etc.).
+
+After evaluating the CrewAI framework found in `vendor/crewAI`, we concluded that
+its abstractions are not required for a minimal command-line agent. The project
+will instead implement its own lightweight orchestration layer in Python.
+
+## Goal
+Create a minimal viable product of a CLI development agent that works outside of
+VSCode. The new agent should reuse Cline's prompting approach and tool semantics
+while implementing its own conversation loop for LLM interaction.
+
+## High level architecture
+1. **CLI entry point** – a Python script (e.g. `src/cli.py`) using `click` or
+   `argparse` to accept the user request. It bootstraps a `DeveloperAgent`
+   configured with our prompts and tools, then enters a loop until the task is
+   complete.
+2. **Agent definition** – implement a simple `DeveloperAgent` class that loads
+   Cline's `SYSTEM_PROMPT` from `vendor/cline/src/core/prompts/system.ts` and
+   coordinates tool usage. The agent operates in a sequential tool-use loop.
+3. **Tool implementations** – Python classes deriving from a lightweight `Tool`
+   base implementing the operations described in the prompts:
+   - `execute_command` – run shell commands with optional approval.
+   - File operations: `read_file`, `write_to_file`, `replace_in_file`.
+   - Project exploration: `search_files`, `list_files`, `list_code_definition_names`.
+   - Additional tools such as `browser_action`, `use_mcp_tool` and
+     `access_mcp_resource` can be stubbed initially.
+4. **Assistant message parser** – port Cline's TypeScript logic from
+   `parse-assistant-message.ts` to Python in order to detect `<tool>` blocks in
+   the model response. This lets the loop know which tool to execute and what
+   parameters were supplied.
+5. **Conversation loop** – similar to Cline's `initiateTaskLoop` in the Task
+   class. The loop will:
+   - Send the user request (plus context) to the LLM.
+   - Parse the assistant reply for tool uses.
+   - Execute the tool and append the result to the conversation history.
+   - Continue until the assistant calls `attempt_completion` or a max iteration
+     limit is reached.
+6. **Context & Memory** – maintain conversation state in memory (e.g. a JSON log).
+   File exploration and search results can be stored as context blocks similar to
+   how Cline does.
+7. **MCP integration** – when `use_mcp_tool` or `access_mcp_resource` is
+   requested, communicate with an MCP server. Documentation for building such
+   servers is loaded via the `load_mcp_documentation` tool from Cline.
+8. **User approvals & safety** – replicate Cline's human‑in‑the‑loop approach by
+   prompting the user before running risky commands (`requires_approval=true`).
+9. **Testing & examples** – provide example workflows and basic unit tests for
+   the parser and tools. Include a sample `Makefile` or `tox` config to run
+   tests.
+
+## Suggested implementation steps
+1. **Set up project structure** in `src/` for Python modules and CLI entry.
+2. **Port prompts** – convert `system.ts` and command prompts to Python multiline
+   strings. Keep the tool descriptions intact.
+3. **Implement tool classes** in Python matching the XML interface defined in the
+   prompts. Initially implement core file and command tools; browser and MCP
+   tools can be added later.
+4. **Write assistant message parser** based on Cline's `parseAssistantMessageV2`
+   to extract tool calls from the model output.
+5. **Create the developer agent** configured with the system prompt and tools.
+   Repeatedly send/receive messages until completion using the custom loop.
+6. **Build CLI script** to accept a user task, run the agent loop and print tool
+   execution results along the way. Provide options to auto‑approve commands or
+   require confirmation.
+7. **Iterate** – add features such as MCP integration, browser actions and
+   context summarization as needed.
+
+## Next steps
+The plan above outlines the major tasks required to adapt the Cline extension
+into a standalone CLI agent. Start by porting the prompts and parsing logic,
+then gradually implement tools and the conversation loop in Python. With a
+minimal orchestration layer we can focus on mapping Cline's capabilities into
+this new environment.

--- a/docs/MVP-TASKS.md
+++ b/docs/MVP-TASKS.md
@@ -1,0 +1,46 @@
+# MVP Task Breakdown
+
+This document enumerates the concrete tasks required to deliver a minimal but functional CLI-based software development agent. Tasks are ordered sequentially so that foundations are built before layering extra features.
+
+## 1. Project initialization
+- **1.1 Inspect vendor code** – review `vendor/cline` for prompts and tool semantics. Optionally consult `vendor/crewAI` for inspiration, but the MVP will not depend on it.
+- **1.2 Set up Python package** – create a `src` package structure and `pyproject.toml` (or `setup.py`). Include basic lint and test configuration (e.g. `ruff`, `pytest`).
+
+## 2. Port Cline prompts
+- **2.1 Extract system prompt** – translate `vendor/cline/src/core/prompts/system.ts` into a Python multiline string (maintain tool descriptions verbatim). Store this in `src/prompts/system.py`.
+- **2.2 Extract command prompts** – convert prompts like `new_task` and `condense` from `commands.ts` to Python templates.
+- **2.3 Provide helper functions** – write small utilities that deliver the appropriate prompt text given runtime options (working directory, browser support, etc.).
+
+## 3. Assistant message parsing
+- **3.1 Port parser logic** – implement a Python version of Cline’s `parseAssistantMessageV2`. It should detect `<tool>` XML blocks in the LLM response and return a structured representation (`tool_name`, parameters, and free text segments).
+- **3.2 Unit tests** – create tests ensuring the parser correctly interprets typical responses and edge cases.
+
+## 4. Core tool implementations
+Implement Python tool classes matching Cline's specification. Each tool exposes a `run()` method.
+
+- **4.1 File tools** – `read_file`, `write_to_file`, `replace_in_file`, `list_files`, and `search_files`.
+- **4.2 Command execution** – `execute_command` with a flag requiring user approval for dangerous commands. Use Python’s `subprocess` module and handle timeouts or errors gracefully.
+- **4.3 Code navigation** – `list_code_definition_names` or similar features to help the agent explore the project. Stub advanced tools (`browser_action`, `use_mcp_tool`, `access_mcp_resource`) but leave hooks for future work.
+- **4.4 Tests for each tool** – verify that file modifications and command execution behave as expected.
+
+## 5. Agent and task loop
+- **5.1 Configure the agent** – build a `DeveloperAgent` class that loads the system prompt, registers the core tools, and defines how messages are sent to the LLM.
+- **5.2 Conversation loop** – replicate Cline’s loop by repeatedly sending user input + tool results to the LLM, parsing its reply, executing the indicated tool, and appending the outcome to the conversation history until `attempt_completion` is triggered or a limit is hit.
+- **5.3 Memory** – maintain short term conversation history and optional file context using our own data structures.
+
+## 6. CLI entry point
+- **6.1 Create `src/cli.py`** – handle command-line arguments (task description, model name, auto-approve flag, etc.).
+- **6.2 Run the agent** – boot the `DeveloperAgent` with the given options and invoke the conversation loop. Print tool outputs in a user-friendly manner.
+- **6.3 Error handling** – catch exceptions, offer to continue or abort on failure, and log actions for later review.
+
+## 7. Documentation and examples
+- **7.1 Update README** – provide instructions on installation, running the CLI and contributing.
+- **7.2 Example workflows** – add a few step-by-step examples demonstrating typical usage (e.g. create a new file, run tests, fix a lint error).
+
+## 8. Further enhancements (post-MVP)
+These tasks are optional for the initial deliverable but should be tracked for future work.
+
+- Integrate `browser_action`, `use_mcp_tool` and `access_mcp_resource` once a backend is available.
+- Consider support for multiple agents collaborating in the future.
+- Add advanced summarization and context condensation using prompts from Cline.
+


### PR DESCRIPTION
## Summary
- remove CrewAI dependency from CODEX_PLAN and tasks
- clarify agent loop implementation steps
- add README with project intent

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684aa852d6888333bbefa6f611f80b11