### PR TITLE
Improve test coverage and fix system prompt regex

### DIFF
--- a/src/prompts/system.py
+++ b/src/prompts/system.py
@@ -629,8 +629,16 @@ You accomplish a given task iteratively, breaking it down into clear steps and w
 5. The user may provide feedback, which you can use to make improvements and try again. But DO NOT continue in pointless back and forth conversations, i.e. don't end your responses with questions or offers for further assistance.
 """
 
-BROWSER_SECTION_PATTERN = re.compile(r"\$\{\s*supportsBrowserUse\s*\?\s*`(.*?)`\s*:\s*\"\"\s*\}", re.DOTALL)
-BROWSER_INLINE_PATTERN = re.compile(r"\$\{\s*supportsBrowserUse\s*\?\s*\"(.*?)\"\s*:\s*\"\"\s*\}")
+BROWSER_SECTION_PATTERN = re.compile(
+    r"\$\{\s*supportsBrowserUse\s*\?\s*(?P<q>[`\"])"
+    r"(?P<content>.*?)"
+    r"(?P=q)\s*:\s*\"\"\s*\}",
+    re.DOTALL,
+)
+BROWSER_INLINE_PATTERN = re.compile(
+    r"\$\{\s*supportsBrowserUse\s*\?\s*\"(.*?)\"\s*:\s*\"\"\s*\}",
+    re.DOTALL,
+)
 MCP_BLOCK_PATTERN = re.compile(r"\$\{\s*mcpHub\.getServers\(\).*?:\s*\"(No MCP servers currently connected)\"\s*\}", re.DOTALL)
 
 def get_system_prompt(cwd: str, supports_browser_use: bool = False, browser_settings: dict | None = None) -> str:
@@ -648,7 +656,7 @@ def get_system_prompt(cwd: str, supports_browser_use: bool = False, browser_sett
     prompt = prompt.replace("${browserSettings.viewport.width}", width)
     prompt = prompt.replace("${browserSettings.viewport.height}", height)
     if supports_browser_use:
-        prompt = BROWSER_SECTION_PATTERN.sub(lambda m: m.group(1), prompt)
+        prompt = BROWSER_SECTION_PATTERN.sub(lambda m: m.group("content"), prompt)
         prompt = BROWSER_INLINE_PATTERN.sub(lambda m: m.group(1), prompt)
     else:
         prompt = BROWSER_SECTION_PATTERN.sub("", prompt)

--- a/tests/test_assistant_message_extra.py
+++ b/tests/test_assistant_message_extra.py
@@ -1,0 +1,30 @@
+from src.assistant_message import _extract_param, parse_assistant_message, TextContent, ToolUse
+
+
+def test_extract_param_full():
+    block = '<path>foo.txt</path>'
+    assert _extract_param(block, 'path') == 'foo.txt'
+
+
+def test_extract_param_partial():
+    block = '<path>foo.txt'
+    assert _extract_param(block, 'path') == 'foo.txt'
+
+
+def test_extract_param_missing():
+    block = '<other>hi</other>'
+    assert _extract_param(block, 'path') is None
+
+
+def test_unknown_tag_ignored():
+    msg = 'test <unknown>data</unknown> end'
+    result = parse_assistant_message(msg)
+    assert result == [TextContent(type='text', content='test'), TextContent(type='text', content='data'), TextContent(type='text', content='end')]
+
+
+def test_adjacent_text_segments():
+    msg = 'hello <read_file><path>a.txt</path></read_file>world'
+    result = parse_assistant_message(msg)
+    assert isinstance(result[1], ToolUse)
+    assert result[0].content == 'hello'
+    assert result[2].content == 'world'

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1,0 +1,26 @@
+import os
+import platform
+from src.prompts.system import get_system_prompt
+
+
+def test_placeholder_replacement(monkeypatch):
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(os.path, "expanduser", lambda x: "/home/test")
+    prompt = get_system_prompt("/work")
+    assert "/work" in prompt
+    assert "Darwin" in prompt
+    assert "/bin/zsh" in prompt
+    assert "/home/test" in prompt
+
+
+def test_browser_sections(monkeypatch):
+    monkeypatch.setenv("SHELL", "/bin/sh")
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    prompt_no = get_system_prompt("/work", supports_browser_use=False)
+    prompt_yes = get_system_prompt("/work", supports_browser_use=True, browser_settings={"viewport": {"width": 800, "height": 600}})
+    phrase = "Puppeteer-controlled browser when you feel it is necessary"
+    assert phrase not in prompt_no
+    assert phrase in prompt_yes
+    assert "800x600" in prompt_yes
+


### PR DESCRIPTION
## Summary
- add unit tests for extra cases in assistant message parsing
- cover system prompt customization with new tests
- fix regex handling for browser support sections in system prompt

## Testing
- `ruff check src/prompts/system.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad703b4ec8333aabe4882ca18fd7a