### PR TITLE
Implement execute_command tool

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -5,6 +5,7 @@ from .file import (
     list_files,
     search_files,
 )
+from .command import execute_command
 
 __all__ = [
     "read_file",
@@ -12,4 +13,5 @@ __all__ = [
     "replace_in_file",
     "list_files",
     "search_files",
+    "execute_command",
 ]

--- a/src/tools/command.py
+++ b/src/tools/command.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import subprocess
+from typing import Tuple, Optional
+
+
+def execute_command(
+    command: str,
+    requires_approval: bool,
+    *,
+    auto_approve: bool = False,
+    timeout: Optional[int] = None,
+) -> Tuple[bool, str]:
+    """Execute a shell command and return success flag and output."""
+    if requires_approval and not auto_approve:
+        resp = input(f"Approve command '{command}'? [y/N]: ").strip().lower()
+        if resp not in {"y", "yes"}:
+            return False, "Command rejected by user"
+
+    try:
+        completed = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "Command timed out"
+    except Exception as exc:  # pragma: no cover - generic unexpected errors
+        return False, f"Error executing command: {exc}"
+
+    output = (completed.stdout or "") + (completed.stderr or "")
+    success = completed.returncode == 0
+    return success, output.strip()

--- a/tests/test_command_tool.py
+++ b/tests/test_command_tool.py
@@ -1,0 +1,29 @@
+import sys
+
+from src.tools import execute_command
+
+
+def test_execute_command_success():
+    success, output = execute_command("echo hello", requires_approval=False)
+    assert success
+    assert "hello" in output
+
+
+def test_execute_command_rejected(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    success, output = execute_command("echo hi", requires_approval=True)
+    assert not success
+    assert "rejected" in output.lower()
+
+
+def test_execute_command_timeout():
+    cmd = f"{sys.executable} -c \"import time; time.sleep(2)\""
+    success, output = execute_command(cmd, requires_approval=False, timeout=0.5)
+    assert not success
+    assert "timed out" in output.lower()
+
+
+def test_execute_command_error():
+    success, output = execute_command("nonexistentcommand_xyz", requires_approval=False)
+    assert not success
+    assert output

--- a/tests/test_file_tools.py
+++ b/tests/test_file_tools.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from src.tools import (


### PR DESCRIPTION
## Summary
- implement `execute_command` tool using subprocess with optional approval
- expose new tool from `src.tools`
- add unit tests for command execution
- fix lint warning in tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae150352083338c8d8c4fb34871e9