### PR TITLE
Implement code navigation tool

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -6,6 +6,12 @@ from .file import (
     search_files,
 )
 from .command import execute_command
+from .code import (
+    list_code_definition_names,
+    browser_action,
+    use_mcp_tool,
+    access_mcp_resource,
+)
 
 __all__ = [
     "read_file",
@@ -14,4 +20,8 @@ __all__ = [
     "list_files",
     "search_files",
     "execute_command",
+    "list_code_definition_names",
+    "browser_action",
+    "use_mcp_tool",
+    "access_mcp_resource",
 ]

--- a/src/tools/code.py
+++ b/src/tools/code.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+import ast
+from typing import List
+
+
+def _python_top_level_defs(file_path: Path) -> List[str]:
+    source = file_path.read_text(encoding="utf-8")
+    try:
+        module = ast.parse(source)
+    except SyntaxError:
+        return []
+    lines = source.splitlines()
+    defs = []
+    for node in module.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            line = lines[node.lineno - 1].rstrip()
+            defs.append("|" + line)
+    return defs
+
+
+def list_code_definition_names(path: str) -> str:
+    """List top level definition names for supported source files in directory."""
+    p = Path(path)
+    if not p.is_dir():
+        raise ValueError("path must be a directory")
+
+    result_lines: List[str] = []
+    for entry in sorted(p.iterdir()):
+        if not entry.is_file():
+            continue
+        if entry.suffix == ".py":
+            defs = _python_top_level_defs(entry)
+        else:
+            defs = []
+        if defs:
+            result_lines.append(entry.name)
+            result_lines.append("|----")
+            result_lines.extend(defs)
+            result_lines.append("|----")
+            result_lines.append("")
+    if not result_lines:
+        return "No source code definitions found."
+    return "\n".join(result_lines).rstrip()
+
+
+def browser_action(*args, **kwargs):
+    """Stub for browser_action tool."""
+    raise NotImplementedError("browser_action is not implemented yet")
+
+
+def use_mcp_tool(*args, **kwargs):
+    """Stub for use_mcp_tool tool."""
+    raise NotImplementedError("use_mcp_tool is not implemented yet")
+
+
+def access_mcp_resource(*args, **kwargs):
+    """Stub for access_mcp_resource tool."""
+    raise NotImplementedError("access_mcp_resource is not implemented yet")

--- a/tests/test_code_navigation.py
+++ b/tests/test_code_navigation.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from src.tools import list_code_definition_names
+
+
+def test_list_code_definition_names(tmp_path: Path):
+    (tmp_path / "module.py").write_text(
+        """class Foo:\n    pass\n\n\ndef bar():\n    return 1\n\nclass Baz:\n    pass\n""",
+        encoding="utf-8",
+    )
+    (tmp_path / "ignore.txt").write_text("hello")
+
+    result = list_code_definition_names(str(tmp_path))
+    lines = result.splitlines()
+    assert lines[0] == "module.py"
+    assert "|----" in lines[1]
+    assert any("class Foo" in l for l in lines)
+    assert any("def bar" in l for l in lines)
+    assert lines[-1] == "|----"
+
+
+def test_no_definitions(tmp_path: Path):
+    (tmp_path / "a.txt").write_text("no code")
+    assert list_code_definition_names(str(tmp_path)) == "No source code definitions found."


### PR DESCRIPTION
## Summary
- add `list_code_definition_names` for listing top‑level Python definitions
- stub advanced tools (`browser_action`, `use_mcp_tool`, `access_mcp_resource`)
- expose new tools in package init
- test listing definitions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae27192a883339e9b9b20fb29df8e