### PR TITLE
Implement simple memory tracking

### DIFF
--- a/src/memory.py
+++ b/src/memory.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class Memory:
+    """Simple in-memory storage for conversation history and file context."""
+
+    history: List[Dict[str, str]] = field(default_factory=list)
+    file_context: Dict[str, str] = field(default_factory=dict)
+
+    def add_message(self, role: str, content: str) -> None:
+        """Append a message to the conversation history."""
+        self.history.append({"role": role, "content": content})
+
+    def add_file_context(self, path: str, content: str) -> None:
+        """Store the latest known content for *path* in memory."""
+        self.file_context[path] = content
+
+    def get_history(self) -> List[Dict[str, str]]:
+        """Return a copy of the message history."""
+        return list(self.history)
+
+    def get_file_context(self) -> Dict[str, str]:
+        """Return a copy of stored file contents."""
+        return dict(self.file_context)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from src.agent import DeveloperAgent
+
+
+def test_memory_tracking(tmp_path: Path):
+    file_path = tmp_path / "data.txt"
+    file_path.write_text("hello", encoding="utf-8")
+    responses = [
+        f"<read_file><path>{file_path.name}</path></read_file>",
+        "<attempt_completion><result>done</result></attempt_completion>",
+    ]
+
+    def fake_send(history):
+        return responses.pop(0)
+
+    agent = DeveloperAgent(fake_send, cwd=str(tmp_path), auto_approve=True)
+    result = agent.run_task("start")
+    assert result == "done"
+    assert agent.memory.file_context[str(file_path)] == "hello"
+    assert len(agent.memory.history) == 5


### PR DESCRIPTION
## Summary
- introduce a `Memory` class to store conversation history and file context
- use `Memory` in `DeveloperAgent` to record messages and file reads
- track file contents in memory when `read_file` is executed
- test the new memory behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae7cbc48c8333854352e460346a8d