### PR TITLE
Implement CLI entry point with mock LLM backend

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import List, Optional
+
+from .agent import DeveloperAgent
+from .llm import MockLLM
+
+
+def setup_logging(log_file: str = "agent.log") -> None:
+    logging.basicConfig(
+        filename=log_file,
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+
+def run_agent(task: str, responses_file: str, *, auto_approve: bool = False, cwd: str = ".") -> str:
+    llm = MockLLM.from_file(responses_file)
+    agent = DeveloperAgent(llm.send_message, cwd=cwd, auto_approve=auto_approve)
+    result = agent.run_task(task)
+    return result
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="CLI developer agent")
+    parser.add_argument("task", help="Task description")
+    parser.add_argument(
+        "--model",
+        default="mock",
+        help="Model name to use (only 'mock' supported)",
+    )
+    parser.add_argument(
+        "--responses-file",
+        help="Path to JSON file with mock LLM responses",
+    )
+    parser.add_argument("--auto-approve", action="store_true", help="Auto approve commands")
+    parser.add_argument("--cwd", default=".", help="Working directory")
+    args = parser.parse_args(argv)
+
+    setup_logging()
+    logging.info("Starting agent for task: %s", args.task)
+
+    if args.model != "mock":
+        parser.error("Only the mock model backend is implemented")
+
+    if not args.responses_file:
+        parser.error("--responses-file is required when using the mock model")
+
+    try:
+        result = run_agent(
+            args.task,
+            args.responses_file,
+            auto_approve=args.auto_approve,
+            cwd=args.cwd,
+        )
+    except Exception as exc:  # pragma: no cover - unexpected failures
+        logging.exception("Agent run failed")
+        print(f"Error: {exc}", file=sys.stderr)
+        resp = input("Continue anyway? [y/N]: ").strip().lower()
+        if resp not in {"y", "yes"}:
+            print("Aborted.", file=sys.stderr)
+            return 1
+        return 0
+
+    print(result)
+    logging.info("Agent completed successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llm.py
+++ b/src/llm.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+
+class MockLLM:
+    """Simple mock LLM that returns predefined responses."""
+
+    def __init__(self, responses: List[str]):
+        self._responses = list(responses)
+        self._index = 0
+
+    @classmethod
+    def from_file(cls, path: str) -> "MockLLM":
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            raise ValueError("responses file must contain a JSON list")
+        return cls([str(item) for item in data])
+
+    def send_message(self, history: List[Dict[str, str]]) -> str:
+        if self._index >= len(self._responses):
+            return ""
+        resp = self._responses[self._index]
+        self._index += 1
+        return resp

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,28 @@
+from src.cli import main
+import json
+
+
+def test_cli_basic(tmp_path, capsys):
+    responses = [
+        "<write_to_file><path>out.txt</path><content>hi</content></write_to_file>",
+        "<attempt_completion><result>done</result></attempt_completion>",
+    ]
+    resp_file = tmp_path / "responses.json"
+    resp_file.write_text(json.dumps(responses), encoding="utf-8")
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+
+    exit_code = main([
+        "do something",
+        "--responses-file",
+        str(resp_file),
+        "--auto-approve",
+        "--cwd",
+        str(cwd),
+    ])
+
+    assert exit_code == 0
+    assert (cwd / "out.txt").read_text(encoding="utf-8") == "hi"
+    out = capsys.readouterr().out
+    assert "done" in out


### PR DESCRIPTION
## Summary
- create `MockLLM` helper to feed canned responses
- add `cli.py` with argument parsing and basic error handling
- new tests exercising CLI behaviour

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae9a3dc8883339bf2d32560cecdbe