### PR TITLE
Implement parser and dispatch improvements

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -51,7 +51,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--model",
         default="mock",
-        help="Model name to use (only 'mock' supported)",
+        help="Model name to use ('mock' or OpenRouter model name)",
     )
     parser.add_argument(
         "--responses-file",

--- a/src/llm.py
+++ b/src/llm.py
@@ -4,7 +4,17 @@ import json
 from pathlib import Path
 from typing import List, Dict
 
+from typing import Protocol
+
 from openai import OpenAI
+
+
+class LLMWrapper(Protocol):
+    """Interface for language model backends."""
+
+    def send_message(self, history: List[Dict[str, str]]) -> str:
+        """Return an assistant reply for the given message history."""
+        ...
 
 
 class MockLLM:


### PR DESCRIPTION
## Summary
- refactor DeveloperAgent's `_run_tool` to use handler dispatch
- simplify boolean parsing
- update CLI help message
- add `LLMWrapper` protocol for language models
- overhaul message parsing with `xml.etree.ElementTree`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b03b93c6c8333ba4a52a042d3877a