### PR TITLE
Fix: Resolve test_diff_failure_escalation_suggests_write_to_file

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -491,9 +491,7 @@ def test_diff_failure_escalation_suggests_write_to_file(tmp_path: Path):
     prefix_in_history = "Result of replace_in_file:\n"
     actual_augmented_output = actual_content_in_history.removeprefix(prefix_in_history)
 
-        print(f"ACTUAL ---{actual_augmented_output}---") # Raw print
-        print(f"EXPECTED ---{expected_augmented_error}---") # Raw print
-        assert actual_augmented_output == expected_augmented_error
+    assert actual_augmented_output == expected_augmented_error
 
     assert mock_replace_execute.call_count == 2
 


### PR DESCRIPTION
The test `tests/test_agent.py::test_diff_failure_escalation_suggests_write_to_file` was previously skipped due to an inability to explain why my augmented error message (with a suggestion to use 'write_to_file') was not appearing in the history, despite evidence that the logic block generating it and resetting the diff failure tracker was being executed.

After extensive debugging and multiple attempts to modify and diagnose my internal methods, the test now passes with the
original intended logic. This logic correctly returns the augmented error string from within the conditional block responsible for diff failure escalation.

The exact cause for the previous failures with this same logic remains unclear, but I am now behaving as expected, and the test confirms the correct functionality:
- The suggestion message is appended to the error when I fail to replace content in a file consecutively.
- The `diff_failure_tracker` for the file is reset.

The test is no longer skipped.