### PR TITLE
Add git auto-commit feature

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -30,6 +30,7 @@ def run_agent(
     allow_execute_all_commands: bool = False,
     allow_use_browser: bool = False,
     allow_use_mcp: bool = False,
+    disable_git_auto_commits: bool = False,
     cwd: str = ".",
     model: str = "mock",
     return_history: bool = False,
@@ -61,6 +62,7 @@ def run_agent(
         cli_args.allow_execute_all_commands = allow_execute_all_commands
         cli_args.allow_use_browser = allow_use_browser
         cli_args.allow_use_mcp = allow_use_mcp
+        cli_args.disable_git_auto_commits = disable_git_auto_commits
 
     if model == "mock":
         if not responses_file:
@@ -89,6 +91,7 @@ def run_agent(
         cwd=cwd,
         cli_args=cli_args, # Pass the whole namespace
         matching_strictness=matching_strictness
+        ,disable_git_auto_commits=disable_git_auto_commits
         # Removed individual approval flags, they are now in cli_args
     )
     result = agent.run_task(task)
@@ -160,6 +163,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         default=100,
         help="Set the string matching strictness for file edits (0-100, 100 is exact match).",
     )
+    parser.add_argument(
+        "--disable-git-auto-commits",
+        action="store_true",
+        default=False,
+        help="Disable automatic git commits after file modifications.",
+    )
     args = parser.parse_args(argv)
 
     if not (0 <= args.matching_strictness <= 100):
@@ -184,6 +193,7 @@ def main(argv: Optional[List[str]] = None) -> int:
             allow_execute_all_commands=args.allow_execute_all_commands,
             allow_use_browser=args.allow_use_browser,
             allow_use_mcp=args.allow_use_mcp,
+            disable_git_auto_commits=args.disable_git_auto_commits,
             cwd=args.cwd,
             model=args.model,
             llm_timeout=args.llm_timeout,

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from typing import Union # Union is used in the type hint
+import subprocess
+from pathlib import Path
+
 
 def to_bool(value: Union[str, bool, None]) -> bool:
     """
@@ -25,3 +28,26 @@ def to_bool(value: Union[str, bool, None]) -> bool:
         raise ValueError(f"Cannot convert string '{value}' to boolean. Expected 'true' or 'false'.")
     # If it's not bool, None, or str, it's an unexpected type for this conversion
     raise TypeError(f"Cannot convert value of type {type(value)} to boolean. Expected str, bool, or None.")
+
+
+def commit_all_changes(cwd: str, message: str = "Auto-commit") -> str | None:
+    """Commit all changes in the given directory using git and return the commit hash.
+
+    If the directory is not a git repository or there are no changes to commit,
+    the function silently returns ``None``.
+    """
+    repo_path = Path(cwd)
+    if not (repo_path / ".git").exists():
+        return None
+    try:
+        subprocess.run(["git", "add", "-A"], cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        diff_proc = subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=cwd)
+        if diff_proc.returncode == 0:
+            return None
+        subprocess.run(["git", "commit", "-m", message], cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        commit_id = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=cwd).decode().strip()
+        print(f"Auto-commit id: {commit_id}")
+        return commit_id
+    except Exception:
+        return None
+

--- a/tests/test_git_auto_commit.py
+++ b/tests/test_git_auto_commit.py
@@ -1,0 +1,79 @@
+import subprocess
+import argparse
+from pathlib import Path
+
+from src.agent import DeveloperAgent
+
+
+def init_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, stdout=subprocess.PIPE)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+
+
+def commit_count(path: Path) -> int:
+    out = subprocess.check_output(["git", "rev-list", "--count", "HEAD"], cwd=path)
+    return int(out.decode().strip())
+
+
+def test_auto_commit_after_write(tmp_path: Path, capsys):
+    init_repo(tmp_path)
+    responses = [
+        "<write_to_file><path>a.txt</path><content>data</content></write_to_file>",
+        "<attempt_completion><result>done</result></attempt_completion>",
+    ]
+
+    def fake_send(_):
+        return responses.pop(0)
+
+    cli_args = argparse.Namespace(
+        auto_approve=True,
+        allow_read_files=True,
+        allow_edit_files=True,
+        allow_execute_safe_commands=True,
+        allow_execute_all_commands=True,
+        allow_use_browser=True,
+        allow_use_mcp=True,
+        disable_git_auto_commits=False,
+    )
+
+    agent = DeveloperAgent(fake_send, cwd=str(tmp_path), cli_args=cli_args)
+    result = agent.run_task("task")
+    assert result == "done"
+    assert commit_count(tmp_path) == 1
+    log = subprocess.check_output(["git", "log", "--oneline"], cwd=tmp_path).decode().splitlines()[0]
+    commit_id = log.split()[0]
+    assert "Auto-commit" in log
+    out = capsys.readouterr().out
+    assert f"Auto-commit id: {commit_id}" in out
+
+
+def test_disable_git_auto_commit(tmp_path: Path):
+    init_repo(tmp_path)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "initial"], cwd=tmp_path, check=True, stdout=subprocess.PIPE)
+    initial = commit_count(tmp_path)
+
+    responses = [
+        "<write_to_file><path>a.txt</path><content>data</content></write_to_file>",
+        "<attempt_completion><result>done</result></attempt_completion>",
+    ]
+
+    def fake_send(_):
+        return responses.pop(0)
+
+    cli_args = argparse.Namespace(
+        auto_approve=True,
+        allow_read_files=True,
+        allow_edit_files=True,
+        allow_execute_safe_commands=True,
+        allow_execute_all_commands=True,
+        allow_use_browser=True,
+        allow_use_mcp=True,
+        disable_git_auto_commits=True,
+    )
+
+    agent = DeveloperAgent(fake_send, cwd=str(tmp_path), cli_args=cli_args)
+    result = agent.run_task("task")
+    assert result == "done"
+    assert commit_count(tmp_path) == initial
+


### PR DESCRIPTION
## Summary
- implement `commit_all_changes` helper for committing repo
- support optional git auto-commits in `DeveloperAgent`
- expose new CLI flag `--disable-git-auto-commits`
- auto-commit on successful file modifications
- test git commit workflow and CLI argument handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c467c43408333a4fb0ee2d745c89b