### PR TITLE
Feat: Add informative footer to LLM responses in CLI

### DIFF
--- a/src/llm_protocol.py
+++ b/src/llm_protocol.py
@@ -1,6 +1,20 @@
 from __future__ import annotations
 
 from typing import List, Dict, Optional, Protocol
+from dataclasses import dataclass
+
+@dataclass
+class LLMUsageInfo:
+    """Stores usage information for an LLM call."""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost: float = 0.0
+
+@dataclass
+class LLMResponse:
+    """Stores the response from an LLM call, including content and usage."""
+    content: Optional[str] = None
+    usage: Optional[LLMUsageInfo] = None
 
 class LLMWrapper(Protocol):
     """
@@ -12,7 +26,7 @@ class LLMWrapper(Protocol):
         messages: List[Dict[str, str]],
         temperature: float = 0.7, # Default value, can be overridden by implementations
         max_tokens: int = 1024     # Default value, can be overridden by implementations
-    ) -> Optional[str]:
+    ) -> Optional[LLMResponse]: # Return type changed
         """
         Sends a list of messages to the LLM and returns the response.
 
@@ -24,7 +38,7 @@ class LLMWrapper(Protocol):
             max_tokens: The maximum number of tokens to generate.
 
         Returns:
-            An Optional[str] representing the LLM's response content,
-            or None if no response is generated.
+            An LLMResponse object containing the LLM's response and usage info,
+            or None if a significant error occurred.
         """
         ...

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -9,7 +9,9 @@ from openai import OpenAI, APITimeoutError, RateLimitError, APIStatusError, APIC
 # from openai.core import Headers # Removed, as it might be causing issues and requests.Response has headers
 from requests import Response # For creating a mock HTTP response for RateLimitError
 
-from src.llm import OpenRouterLLM
+from src.llm import OpenRouterLLM, MockLLM # Added MockLLM
+from src.llm_protocol import LLMResponse, LLMUsageInfo # Added LLMResponse and LLMUsageInfo
+import json # For MockLLM test file
 
 @pytest.fixture
 def mock_openai_client():
@@ -34,10 +36,17 @@ def test_openrouter_llm_send_message_uses_timeout(mock_openai_client):
     mock_choice.message.content = "Test response"
     mock_completion = MagicMock()
     mock_completion.choices = [mock_choice]
+    # No usage attribute in this mock, so default usage is expected
     mock_openai_client.chat.completions.create.return_value = mock_completion
 
     messages = [{"role": "user", "content": "Hello"}]
-    llm.send_message(messages)
+    result = llm.send_message(messages)
+
+    assert isinstance(result, LLMResponse)
+    assert result.content == "Test response"
+    assert isinstance(result.usage, LLMUsageInfo)
+    assert result.usage.prompt_tokens == 0 # Default due to no usage in mock
+    assert result.usage.completion_tokens == 0 # Default due to no usage in mock
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
         model="test/model",
@@ -53,9 +62,14 @@ def test_openrouter_llm_send_message_handles_timeout_error(mock_openai_client):
 
     messages = [{"role": "user", "content": "Hello"}]
     with patch('time.sleep', return_value=None) as mock_sleep:
-        response = llm.send_message(messages)
+        result = llm.send_message(messages)
 
-    assert response is None
+    assert isinstance(result, LLMResponse)
+    assert result.content is None
+    assert isinstance(result.usage, LLMUsageInfo)
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.completion_tokens == 0
+    assert result.usage.cost == 0.0
     assert mock_openai_client.chat.completions.create.call_count == 3
     assert mock_sleep.call_count == 2
 
@@ -68,16 +82,98 @@ def test_openrouter_llm_send_message_no_timeout_set(mock_openai_client):
     mock_choice.message.content = "Test response"
     mock_completion = MagicMock()
     mock_completion.choices = [mock_choice]
+    # No usage attribute in this mock
     mock_openai_client.chat.completions.create.return_value = mock_completion
 
     messages = [{"role": "user", "content": "Hello"}]
-    llm.send_message(messages)
+    result = llm.send_message(messages)
+
+    assert isinstance(result, LLMResponse)
+    assert result.content == "Test response"
+    assert isinstance(result.usage, LLMUsageInfo)
+    assert result.usage.prompt_tokens == 0 # Default
+    assert result.usage.completion_tokens == 0 # Default
+
 
     mock_openai_client.chat.completions.create.assert_called_once_with(
         model="test/model",
         messages=[{"role": "user", "content": "Hello"}],
-        timeout=None
+        timeout=None # Ensure this is not mistaken for LLMResponse content
     )
+
+# --- MockLLM Tests ---
+
+class TestMockLLM:
+    @pytest.fixture
+    def mock_responses_file(self, tmp_path):
+        file_path = tmp_path / "mock_responses.json"
+        responses = ["Test response 1", "Test response 2"]
+        with open(file_path, "w") as f:
+            json.dump(responses, f)
+        return file_path
+
+    def test_mock_llm_from_file(self, mock_responses_file):
+        llm = MockLLM.from_file(str(mock_responses_file))
+        assert isinstance(llm, MockLLM)
+        # First message
+        response1 = llm.send_message([{"role": "user", "content": "Hello 1"}])
+        assert isinstance(response1, LLMResponse)
+        assert response1.content == "Test response 1"
+        assert isinstance(response1.usage, LLMUsageInfo)
+        assert response1.usage.prompt_tokens == 10
+        assert response1.usage.completion_tokens == 20
+        assert response1.usage.cost == 0.0
+        # Second message
+        response2 = llm.send_message([{"role": "user", "content": "Hello 2"}])
+        assert isinstance(response2, LLMResponse)
+        assert response2.content == "Test response 2"
+        assert isinstance(response2.usage, LLMUsageInfo) # Check usage again for second response
+        assert response2.usage.prompt_tokens == 10
+        assert response2.usage.completion_tokens == 20
+        assert response2.usage.cost == 0.0
+
+
+    def test_mock_llm_send_message(self):
+        responses = ["Response A", "Response B"]
+        llm = MockLLM(responses)
+
+        # First message
+        response1 = llm.send_message([{"role": "user", "content": "First message"}])
+        assert isinstance(response1, LLMResponse)
+        assert response1.content == "Response A"
+        assert isinstance(response1.usage, LLMUsageInfo)
+        assert response1.usage.prompt_tokens == 10
+        assert response1.usage.completion_tokens == 20
+        assert response1.usage.cost == 0.0
+
+        # Second message
+        response2 = llm.send_message([{"role": "user", "content": "Second message"}])
+        assert isinstance(response2, LLMResponse)
+        assert response2.content == "Response B"
+        assert isinstance(response2.usage, LLMUsageInfo)
+        assert response2.usage.prompt_tokens == 10
+        assert response2.usage.completion_tokens == 20
+        assert response2.usage.cost == 0.0
+
+    def test_mock_llm_send_message_exhausted(self):
+        responses = ["Single response"]
+        llm = MockLLM(responses)
+
+        # First message - consumes the only response
+        llm.send_message([{"role": "user", "content": "Consume response"}])
+
+        # Second message - responses exhausted
+        exhausted_response = llm.send_message([{"role": "user", "content": "Exhausted"}])
+        assert isinstance(exhausted_response, LLMResponse)
+        assert exhausted_response.content is None
+        assert isinstance(exhausted_response.usage, LLMUsageInfo)
+        assert exhausted_response.usage.prompt_tokens == 10 # Dummy usage still provided
+        assert exhausted_response.usage.completion_tokens == 20
+        assert exhausted_response.usage.cost == 0.0
+
+# --- OpenRouterLLM Tests --- (Keeping separate class for clarity if OpenRouter tests grow)
+# Note: Many existing OpenRouterLLM tests already use mock_openai_client fixture.
+# We will adapt them below.
 
 # --- HTTP Error Retry Tests ---
 
@@ -95,7 +191,7 @@ def test_openrouter_llm_retries_on_ratelimiterror(mock_openai_client):
     mock_successful_choice.message = MagicMock()
     mock_successful_choice.message.content = "Success after retries"
     mock_successful_completion.choices = [mock_successful_choice]
-
+    # No usage in this mock success response
     mock_openai_client.chat.completions.create.side_effect = [
         RateLimitError("Rate limited", response=mock_http_response, body=None),
         RateLimitError("Rate limited again", response=mock_http_response, body=None),
@@ -104,9 +200,13 @@ def test_openrouter_llm_retries_on_ratelimiterror(mock_openai_client):
 
     messages = [{"role": "user", "content": "Test"}]
     with patch('time.sleep', return_value=None) as mock_sleep:
-        response_content = llm.send_message(messages)
+        result = llm.send_message(messages)
 
-    assert response_content == "Success after retries"
+    assert isinstance(result, LLMResponse)
+    assert result.content == "Success after retries"
+    assert isinstance(result.usage, LLMUsageInfo) # Should have default usage
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.completion_tokens == 0
     assert mock_openai_client.chat.completions.create.call_count == 3
     # Check that sleep was called with the Retry-After value
     mock_sleep.assert_any_call(0.1)
@@ -125,7 +225,7 @@ def test_openrouter_llm_retries_on_ratelimiterror_no_retry_after(mock_openai_cli
     mock_successful_choice_one_retry.message = MagicMock()
     mock_successful_choice_one_retry.message.content = "Success after one retry"
     mock_successful_completion_one_retry.choices = [mock_successful_choice_one_retry]
-
+    # No usage in this mock success response
     mock_openai_client.chat.completions.create.side_effect = [
         RateLimitError("Rate limited", response=mock_http_response_no_header, body=None),
         mock_successful_completion_one_retry
@@ -133,9 +233,13 @@ def test_openrouter_llm_retries_on_ratelimiterror_no_retry_after(mock_openai_cli
 
     messages = [{"role": "user", "content": "Test"}]
     with patch('time.sleep', return_value=None) as mock_sleep:
-        response_content = llm.send_message(messages)
+        result = llm.send_message(messages)
 
-    assert response_content == "Success after one retry"
+    assert isinstance(result, LLMResponse)
+    assert result.content == "Success after one retry"
+    assert isinstance(result.usage, LLMUsageInfo) # Default usage
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.completion_tokens == 0
     assert mock_openai_client.chat.completions.create.call_count == 2
     mock_sleep.assert_called_once_with(1.0) # base_delay * (2**0)
 
@@ -151,7 +255,7 @@ def test_openrouter_llm_retries_on_apistatuserror_5xx(mock_openai_client):
     mock_successful_choice_5xx.message = MagicMock()
     mock_successful_choice_5xx.message.content = "Success after 5xx retry"
     mock_successful_completion_5xx.choices = [mock_successful_choice_5xx]
-
+    # No usage in this mock success response
     mock_openai_client.chat.completions.create.side_effect = [
         APIStatusError("Server error", response=mock_http_response_500, body=None),
         mock_successful_completion_5xx
@@ -159,9 +263,13 @@ def test_openrouter_llm_retries_on_apistatuserror_5xx(mock_openai_client):
 
     messages = [{"role": "user", "content": "Test"}]
     with patch('time.sleep', return_value=None) as mock_sleep:
-        response_content = llm.send_message(messages)
+        result = llm.send_message(messages)
 
-    assert response_content == "Success after 5xx retry"
+    assert isinstance(result, LLMResponse)
+    assert result.content == "Success after 5xx retry"
+    assert isinstance(result.usage, LLMUsageInfo) # Default usage
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.completion_tokens == 0
     assert mock_openai_client.chat.completions.create.call_count == 2
     mock_sleep.assert_called_once_with(1.0) # Exponential backoff
 
@@ -178,9 +286,14 @@ def test_openrouter_llm_no_retry_on_apistatuserror_4xx_client_error(mock_openai_
 
     messages = [{"role": "user", "content": "Test"}]
     with patch('time.sleep', return_value=None) as mock_sleep:
-        response_content = llm.send_message(messages)
+        result = llm.send_message(messages)
 
-    assert response_content is None
+    assert isinstance(result, LLMResponse)
+    assert result.content is None
+    assert isinstance(result.usage, LLMUsageInfo)
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.completion_tokens == 0
+    assert result.usage.cost == 0.0
     assert mock_openai_client.chat.completions.create.call_count == 1 # Fails on first attempt
     assert mock_sleep.call_count == 0 # No sleep, no retry
 
@@ -197,9 +310,14 @@ def test_openrouter_llm_all_retries_exhausted(mock_openai_client):
 
     messages = [{"role": "user", "content": "Test"}]
     with patch('time.sleep', return_value=None) as mock_sleep:
-        response_content = llm.send_message(messages)
+        result = llm.send_message(messages)
 
-    assert response_content is None
+    assert isinstance(result, LLMResponse)
+    assert result.content is None
+    assert isinstance(result.usage, LLMUsageInfo)
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.completion_tokens == 0
+    assert result.usage.cost == 0.0
     assert mock_openai_client.chat.completions.create.call_count == 3
     assert mock_sleep.call_count == 2 # Sleeps between 3 attempts
 
@@ -212,7 +330,7 @@ def test_openrouter_llm_retries_on_apiconnectionerror(mock_openai_client):
     mock_successful_choice_conn_err.message = MagicMock()
     mock_successful_choice_conn_err.message.content = "Success after connection error"
     mock_successful_completion_conn_err.choices = [mock_successful_choice_conn_err]
-
+    # No usage in this mock success response
     mock_openai_client.chat.completions.create.side_effect = [
         APIConnectionError(request=MagicMock()), # Simulate connection error
         mock_successful_completion_conn_err
@@ -220,11 +338,95 @@ def test_openrouter_llm_retries_on_apiconnectionerror(mock_openai_client):
 
     messages = [{"role": "user", "content": "Test"}]
     with patch('time.sleep', return_value=None) as mock_sleep:
-        response_content = llm.send_message(messages)
+        result = llm.send_message(messages)
 
-    assert response_content == "Success after connection error"
+    assert isinstance(result, LLMResponse)
+    assert result.content == "Success after connection error"
+    assert isinstance(result.usage, LLMUsageInfo) # Default usage
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.completion_tokens == 0
     assert mock_openai_client.chat.completions.create.call_count == 2
     mock_sleep.assert_called_once_with(1.0) # Exponential backoff
+
+def test_openrouter_llm_send_message_success_with_usage(mock_openai_client):
+    """Test successful message sending and includes usage info."""
+    llm = OpenRouterLLM(model="test/model", api_key="test_key")
+
+    mock_choice = MagicMock()
+    mock_choice.message = MagicMock()
+    mock_choice.message.content = "Successful response with usage"
+
+    mock_completion = MagicMock()
+    mock_completion.choices = [mock_choice]
+    mock_completion.usage = MagicMock() # Simulate usage attribute
+    mock_completion.usage.prompt_tokens = 70
+    mock_completion.usage.completion_tokens = 80
+
+    mock_openai_client.chat.completions.create.return_value = mock_completion
+
+    messages = [{"role": "user", "content": "Hello with usage"}]
+    result = llm.send_message(messages)
+
+    assert isinstance(result, LLMResponse)
+    assert result.content == "Successful response with usage"
+    assert isinstance(result.usage, LLMUsageInfo)
+    assert result.usage.prompt_tokens == 70
+    assert result.usage.completion_tokens == 80
+    assert result.usage.cost == 0.0 # Cost is not calculated from API response yet
+
+def test_openrouter_llm_send_message_no_content(mock_openai_client):
+    """Test message sending where API returns no content but provides usage."""
+    llm = OpenRouterLLM(model="test/model", api_key="test_key")
+
+    mock_choice_no_content = MagicMock()
+    mock_choice_no_content.message = MagicMock()
+    mock_choice_no_content.message.content = None # No content
+
+    mock_completion_no_content = MagicMock()
+    mock_completion_no_content.choices = [mock_choice_no_content]
+    mock_completion_no_content.usage = MagicMock()
+    mock_completion_no_content.usage.prompt_tokens = 15
+    mock_completion_no_content.usage.completion_tokens = 5 # e.g. filter/stop
+
+    mock_openai_client.chat.completions.create.return_value = mock_completion_no_content
+
+    messages = [{"role": "user", "content": "Trigger no content"}]
+    result = llm.send_message(messages)
+
+    assert isinstance(result, LLMResponse)
+    assert result.content is None
+    assert isinstance(result.usage, LLMUsageInfo)
+    assert result.usage.prompt_tokens == 15
+    assert result.usage.completion_tokens == 5
+    assert result.usage.cost == 0.0
+
+def test_openrouter_llm_send_message_no_usage_from_api(mock_openai_client):
+    """Test message sending where API returns content but no usage info."""
+    llm = OpenRouterLLM(model="test/model", api_key="test_key")
+
+    mock_choice_content_only = MagicMock()
+    mock_choice_content_only.message = MagicMock()
+    mock_choice_content_only.message.content = "Content but no usage"
+
+    mock_completion_no_usage = MagicMock()
+    mock_completion_no_usage.choices = [mock_choice_content_only]
+    # Simulate response object where 'usage' attribute might be missing or None
+    # One way: mock_completion_no_usage.usage = None
+    # Another way: ensure hasattr(mock_completion_no_usage, 'usage') is false
+    # For this test, setting it to None is sufficient as OpenRouterLLM checks `response.usage` (truthiness)
+    mock_completion_no_usage.usage = None
+
+    mock_openai_client.chat.completions.create.return_value = mock_completion_no_usage
+
+    messages = [{"role": "user", "content": "Trigger no usage info"}]
+    result = llm.send_message(messages)
+
+    assert isinstance(result, LLMResponse)
+    assert result.content == "Content but no usage"
+    assert isinstance(result.usage, LLMUsageInfo) # Should fall back to default
+    assert result.usage.prompt_tokens == 0
+    assert result.usage.completion_tokens == 0
+    assert result.usage.cost == 0.0
 
 # To run this file directly for testing:
 # pytest tests/test_llm.py


### PR DESCRIPTION
This commit introduces a footer displayed after each LLM response in the CLI, providing usage statistics and cost information.

Key changes:

- Defined `LLMUsageInfo` and `LLMResponse` data structures in `src/llm_protocol.py` to carry token counts, cost (placeholder for now), and content.
- Updated `LLMWrapper` protocol and its implementations (`OpenRouterLLM`, `MockLLM` in `src/llm.py`) to return `LLMResponse` objects.
  - `OpenRouterLLM` now attempts to parse `usage` (prompt_tokens, completion_tokens) from the API response. Cost is currently set to 0.0.
  - `MockLLM` returns dummy usage data.
- Modified `DeveloperAgent` in `src/agent.py`:
  - To handle the new `LLMResponse` structure.
  - To accumulate `current_session_cost` (currently sums up the placeholder 0.0 costs).
  - Added an `on_llm_response_callback` to notify external listeners (like the CLI) after an LLM call.
- Updated `src/cli.py`:
  - Implemented a callback passed to `DeveloperAgent` to receive LLM response details.
  - The callback formats a string containing: Model Name, Prompt Tokens, Completion Tokens, Cost (per call), and Session Cost.
  - This formatted string is displayed in the CLI after the LLM's textual output.
- Unit Tests:
  - Updated tests in `tests/test_llm.py` and `tests/test_agent.py` to align with the new data structures, cost accumulation, and callback mechanisms.
  - Added tests in `tests/test_cli.py` to verify the correct formatting of the statistics string displayed in the UI.

This feature makes the CLI tool more informative by providing you with insights into token usage and associated costs (once actual cost calculation from OpenRouter is integrated).