### PR TITLE
Fix failing tests

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -182,16 +182,18 @@ class OpenRouterLLM(LLMWrapper):  # Indicate conformance to the protocol
 
 
         for cost_val in cost_sources_values:
-            if cost_val is not None:
+            if cost_val is not None and isinstance(cost_val, (int, float, str)):
                 try:
                     parsed_cost = float(cost_val)
-                    if parsed_cost >= 0: # Found a valid, non-negative cost
+                    if parsed_cost >= 0:  # Found a valid, non-negative cost
                         break
                 except (TypeError, ValueError):
                     continue  # Try next source if current one is not a valid float
 
         def _to_int_internal(val: Any) -> int:
             if val is None:
+                return 0
+            if not isinstance(val, (int, float, str)):
                 return 0
             try:
                 return int(val)


### PR DESCRIPTION
## Summary
- handle permission denial messages when params missing
- ensure diff failure tracker sees errors starting with "Error"
- log file mention issues consistently
- update ReplaceInFileTool regex logic and messages
- ignore non-number mock values when parsing cost

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df9a27aa483339b4685ca9a2755f4